### PR TITLE
Method Macro Expansion proposal

### DIFF
--- a/lib/coffee-script/macro.js
+++ b/lib/coffee-script/macro.js
@@ -50,7 +50,7 @@
   callFunc.stopStackTrace = true;
 
   exports.expand = function(ast, csToNodes) {
-    var context, getCalleeName, k, utils, v;
+    var context, getCalleeName, getMethodNameAndOwner, k, utils, v;
     root.cfg = context = {};
     root.macro = utils = {
       require: require,
@@ -105,6 +105,16 @@
         return name;
       }
     };
+    getMethodNameAndOwner = function(node) {
+      var name, owner, _ref, _ref1, _ref2;
+      if (node instanceof nodeTypes.Call && (owner = (_ref = node.variable) != null ? _ref.properties : void 0) && (name = (_ref1 = owner[owner.length - 1]) != null ? (_ref2 = _ref1.name) != null ? _ref2.value : void 0 : void 0)) {
+        owner = node.variable.subst({});
+        owner.properties.pop();
+        return [name, owner];
+      } else {
+        return [null, null];
+      }
+    };
     utils._macros = {
       macro: function(arg) {
         var name;
@@ -126,6 +136,20 @@
         }
         throw new Error("macro expects a closure or identifier");
       },
+      "macro.defmethod": function(arg) {
+        var name;
+        if (arguments.length !== 1) {
+          throw new Error("macro.defmethod expects 1 argument, got " + arguments.length);
+        }
+        if ((name = getCalleeName(arg))) {
+          if (!(arg.args.length === 1 && arg.args[0] instanceof nodeTypes.Code)) {
+            throw new Error("macro.defmethod expects a closure after identifier");
+          }
+          utils._methodMacros[name] = getFunc(arg.args[0]);
+          return;
+        }
+        throw new Error("macro.defmethod expects a closure or identifier");
+      },
       "macro.codeToNode": function(func) {
         var num;
         if (!(func instanceof nodeTypes.Code) || func.params.length) {
@@ -136,13 +160,14 @@
         return utils.jsToNode("macro._codeNodes[" + num + "]");
       }
     };
+    utils._methodMacros = {};
     return nodeTypes.walk(ast, function(n) {
-      var func, ld, name, res;
-      if ((name = getCalleeName(n)) && (func = utils._macros[name])) {
+      var ld, name, owner, res, _ref;
+      if (((name = getCalleeName(n)) && (utils._macros.hasOwnProperty(name))) || (_ref = getMethodNameAndOwner(n), name = _ref[0], owner = _ref[1], _ref) && (utils._methodMacros.hasOwnProperty(name))) {
         ld = n.locationData;
         utils.file = ld && helpers.filenames[ld.file_num];
         utils.line = ld && 1 + ld.first_line;
-        res = callFunc(func, context, n.args, ld);
+        res = owner != null ? (n.args.unshift(owner), callFunc(utils._methodMacros[name], context, n.args, ld)) : callFunc(utils._macros[name], context, n.args, ld);
         return (res instanceof nodeTypes.Base ? res : false);
       }
     });


### PR DESCRIPTION
Hello there,

I would like to propose adding support for method macros. They are similar to normal macros, except they take an extra object argument and are used in place of methods. This pull requests implements a rough example implementation of the concept. I used `macro.defmethod` to denote method macro in my implementation, but it serves as a placeholder only and the actual keyword is open for suggestion.

A short example (setting/getting DOM data-\* fields):

``` coffeescript
macro.defmethod $data (el, name, val) ->
        if val?
                macro.codeToNode(-> el.dataset[name] = val).subst {el: el, name: name, val: val}
        else
                macro.codeToNode(-> el.dataset[name]).subst {el: el, name: name}

```

A more extensive example and my main use case for this feature, a JQuery-like utility that compiles to bare-bone HTML5:

``` coffeescript
macro $id (id) ->
    macro.codeToNode(-> document.getElementById id).subst {id: id}
macro $tag (name) -> 
    macro.codeToNode(-> document.getElementsByTagName name).subst {name: name}
macro $class (name) ->
    macro.codeToNode(-> document.getElementsByClassName name).subst {name, name}
macro $query (q) ->
    macro.codeToNode(-> document.querySelector q).subst {q, q}
macro $queryAll (q) ->
    macro.codeToNode(-> document.querySelectorAll q).subst {q, q}

macro.defmethod $data (el, name, val) ->
    if val?
        macro.codeToNode(-> el.dataset[name] = val).subst {el: el, name: name, val: val}
    else
        macro.codeToNode(-> el.dataset[name]).subst {el: el, name: name}

macro.defmethod $css (el, name, val) ->
    if val?
        macro.codeToNode(-> el.style.setPropertyValue(name)).subst {el: el, name: name, val: val}
    else
        macro.codeToNode(-> el.style.getPropertyValue(name)).subst {el: el, name: name}

macro.defmethod $hasClass (el, name) ->
    macro.codeToNode(-> el.classList.contains(name)).subst {el: el, name: name}

macro.defmethod $addClass (el, name) ->
    macro.codeToNode(-> el.classList.add(name)).subst {el: el, name: name}

macro.defmethod $toggleClass (el, name) ->
    macro.codeToNode(-> el.classList.toggle(name)).subst {el: el, name: name}

macro.defmethod $removeClass (el, name) ->
    macro.codeToNode(-> el.classList.remove(name)).subst {el: el, name: name}

$id("myform").$data "user", "foo"
$id("important_text").$css "fontSize", "24px"

```
