### PR TITLE
Exposing utility and UTILITIES in nodes.coffee

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3002,7 +3002,7 @@
 
   })(Base);
 
-  UTILITIES = {
+  exports.UTILITIES = UTILITIES = {
     "extends": function() {
       return "function(child, parent) { for (var key in parent) { if (" + (utility('hasProp')) + ".call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }";
     },
@@ -3050,7 +3050,7 @@
 
   IS_REGEX = /^\//;
 
-  utility = function(name) {
+  exports.utility = utility = function(name) {
     var ref;
     ref = "__" + name;
     Scope.root.assign(ref, UTILITIES[name]());

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2117,7 +2117,7 @@ exports.If = class If extends Base
 # Constants
 # ---------
 
-UTILITIES =
+exports.UTILITIES = UTILITIES =
 
   # Correctly set up a prototype chain for inheritance, including a reference
   # to the superclass for `super()` calls, and copies of any static properties.
@@ -2177,7 +2177,7 @@ IS_REGEX = /^\//
 # ----------------
 
 # Helper for ensuring that utility functions are assigned at the top level.
-utility = (name) ->
+exports.utility = utility = (name) ->
   ref = "__#{name}"
   Scope.root.assign ref, UTILITIES[name]()
   ref
@@ -2231,7 +2231,7 @@ cloneNode = (src) ->
   ret[key] = cloneNode(val) for own key,val of src
   ret
 
-# Recursively calls `visit` for every child of `node`. When `visit` returns 
+# Recursively calls `visit` for every child of `node`. When `visit` returns
 # `false`, the node is removed from the tree (or replaced by `undefined` if
 # that is not possible). When a node is returned, it is used to replace the
 # original node, and `visit` is called again for the replacing node.


### PR DESCRIPTION
First, just wanted to say really great work on this fork. 

I've recently found myself in need of the old `extended` functionality which was removed awhile back (ticket https://github.com/jashkenas/coffee-script/pull/1960), and I figured that this fork might be a good way to add it back in there. I found that exposing `UTILITIES` and `utility` in `nodes.coffee` helps in this case, allowing you to do something like:

``` coffee
macro ->

  # Correctly set up a prototype chain for inheritance, including a reference
  # to the superclass for `super()` calls, and copies of any static properties.
  # and adding back the "extended" functionality
  macro.UTILITIES.extends = -> """
    function(child, parent) {
      for (var key in parent) {
        if (#{macro.utility 'hasProp'}.call(parent, key)) child[key] = parent[key];
      }
      function ctor() { this.constructor = child; }
      ctor.prototype = parent.prototype;
      child.prototype = new ctor();
      if (typeof parent.extended === "function") parent.extended(child);
      child.__super__ = parent.prototype;
      return child;
    }
  """
```

Does this seem like a reasonable use case?
