### PR TITLE
Fix calculation of source index in source map

### DIFF
--- a/lib/coffee-script/sourcemap.js
+++ b/lib/coffee-script/sourcemap.js
@@ -81,12 +81,13 @@
     };
 
     SourceMap.prototype.generate = function(options) {
-      var buffer, dstColumn, dstLine, lastColumn, lastSourceColumn, lastSourceLine, lineMap, loc, needComma, v3, writingline, _i, _j, _len, _len1, _ref, _ref1;
+      var buffer, dstColumn, dstLine, lastColumn, lastSourceColumn, lastSourceIndex, lastSourceLine, lineMap, loc, needComma, v3, writingline, _i, _j, _len, _len1, _ref, _ref1;
       if (options == null) {
         options = {};
       }
       writingline = 0;
       lastColumn = 0;
+      lastSourceIndex = 0;
       lastSourceLine = 0;
       lastSourceColumn = 0;
       needComma = false;
@@ -113,7 +114,8 @@
             }
             buffer += this.encodeVlq(dstColumn - lastColumn);
             lastColumn = dstColumn;
-            buffer += this.encodeVlq(loc.file_num || 0);
+            buffer += this.encodeVlq(loc.file_num - lastSourceIndex);
+            lastSourceIndex = loc.file_num;
             buffer += this.encodeVlq(loc.first_line - lastSourceLine);
             lastSourceLine = loc.first_line;
             buffer += this.encodeVlq(loc.first_column - lastSourceColumn);

--- a/src/sourcemap.litcoffee
+++ b/src/sourcemap.litcoffee
@@ -86,6 +86,7 @@ map.  Also, `options.generatedFile` may be passed to "file".
       generate: (options = {}) ->
         writingline       = 0
         lastColumn        = 0
+        lastSourceIndex   = 0
         lastSourceLine    = 0
         lastSourceColumn  = 0
         needComma         = no
@@ -116,7 +117,8 @@ column for the current line:
 
 The index into the list of sources:
 
-            buffer += @encodeVlq loc.file_num||0
+            buffer += @encodeVlq loc.file_num - lastSourceIndex
+            lastSourceIndex = loc.file_num
 
 The starting line in the original source, relative to the previous source line.
 


### PR DESCRIPTION
Source index is defined by specification as relative to previous occurence of this field.

Exception case when it's a first field occurence and index should be represented by whole value is also handled.
