### PR TITLE
Set file number on top AST node

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -66,7 +66,7 @@
   };
 
   exports.nodes = function(source, options) {
-    var fileNum, nodes;
+    var fileNum, nodes, _ref;
     if (options == null) {
       options = {};
     }
@@ -75,6 +75,9 @@
       source = exports.tokens(source, options);
     }
     nodes = parser.parse(source);
+    if ((_ref = nodes.locationData) != null) {
+      _ref.file_num = fileNum;
+    }
     parser.yy.walk(nodes, function(n) {
       if (n.locationData) {
         n.locationData.file_num = fileNum;

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -61,6 +61,7 @@ exports.nodes = (source, options={}) ->
   nodes = parser.parse source
 
   # Set the `fileNum` on each of the ast nodes.
+  nodes.locationData?.file_num = fileNum
   parser.yy.walk nodes, (n) ->
     n.locationData.file_num = fileNum if n.locationData
     return

--- a/test/location.coffee
+++ b/test/location.coffee
@@ -64,3 +64,18 @@ test "Verify all tokens get a location", ->
     tokens = CoffeeScript.tokens testScript
     for token in tokens
         ok !!token[2]
+
+if require?
+  test "Verify setting of nodes' file number", ->
+    {walk: walkNodes} = require '../src/nodes'
+    eqNodesFileNum = (nodes, fileNum) ->
+      eq nodes.locationData.file_num, fileNum
+      walkNodes nodes, (n) ->
+        eq n.locationData.file_num, fileNum
+        return
+
+    # Get value from *cached* 'helpers' module.
+    firstFileNum = require('../lib/coffee-script/helpers').scripts.length
+
+    eqNodesFileNum CoffeeScript.nodes('a = 1'), firstFileNum
+    eqNodesFileNum CoffeeScript.nodes('a = 2'), firstFileNum + 1


### PR DESCRIPTION
Otherwise some fragments (like IIFE wrapper when `bare` option isn't set) will get `undefined` as a file number.
